### PR TITLE
[feat] toggle 실시간 연동 기능 추가

### DIFF
--- a/src/main/java/com/example/demo/config/CorsConfig.java
+++ b/src/main/java/com/example/demo/config/CorsConfig.java
@@ -1,0 +1,16 @@
+package com.example.demo.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedMethods("*")
+                .allowedOrigins("http://localhost:8000");
+    }
+}

--- a/src/main/java/com/example/demo/controller/FeatureToggleController.java
+++ b/src/main/java/com/example/demo/controller/FeatureToggleController.java
@@ -1,12 +1,13 @@
 package com.example.demo.controller;
 
 import com.example.demo.model.Feature;
+import com.example.demo.model.FeatureMessageDto;
 import com.example.demo.service.FeatureToggleService;
+import jakarta.websocket.server.PathParam;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,7 +21,16 @@ public class FeatureToggleController {
 
     @GetMapping("/toggle")
     public Feature.Response toggle() {
+        log.info("toggle request in");
         List<Feature.Toggle> allFeature = featureToggleService.getAllFeature();
         return new Feature.Response(allFeature);
+    }
+
+    @ResponseStatus(code = HttpStatus.CREATED)
+    @PutMapping("/toggle")
+    public Feature.UpdateResponse updateToggle(@RequestParam("toggleId") String toggleId,
+                                               @RequestParam("enabled") boolean enabled) {
+        featureToggleService.publishChangedToggleStatus(new FeatureMessageDto(String.valueOf(enabled), toggleId));
+        return new Feature.UpdateResponse(toggleId, enabled);
     }
 }

--- a/src/main/java/com/example/demo/model/Feature.java
+++ b/src/main/java/com/example/demo/model/Feature.java
@@ -12,4 +12,10 @@ public record Feature(
             String feature,
             boolean isEnabled
     ){}
+
+    public record UpdateResponse(
+            String featureId,
+            boolean isEnabled
+    ) {
+    }
 }

--- a/src/main/java/com/example/demo/repository/ToggleRedisRepository.java
+++ b/src/main/java/com/example/demo/repository/ToggleRedisRepository.java
@@ -16,7 +16,6 @@ import java.util.Map;
 public class ToggleRedisRepository implements ToggleRepository{
 
     private final RedisTemplate<String, String> redisTemplate;
-    private final RedisConnectionFactory connectionFactory;
     private final RedisConnectionFactory redisConnectionFactory;
 
     private final static String MATCH_PREFIX = "toggle*";

--- a/src/main/java/com/example/demo/service/DemoService1.java
+++ b/src/main/java/com/example/demo/service/DemoService1.java
@@ -1,19 +1,22 @@
 package com.example.demo.service;
 
 import com.example.demo.toggle.Toggle;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class DemoService1 implements DemoServicePort{
 
     @Override
-    @Toggle(value = "toggle:feature2", fallbackMethod = "fallbackMethod")
+    @Toggle(featureId = "toggle:feature2", fallbackMethod = "fallbackMethod")
     public String justPrint() {
         return "justPrint";
+    }
+
+    @Toggle(featureId = "toggle:feature3", fallbackMethod = "fallbackMethod")
+    public String justPrint2() {
+        return "justPrint2";
     }
 
     public String fallbackMethod() {

--- a/src/main/java/com/example/demo/service/DemoService2.java
+++ b/src/main/java/com/example/demo/service/DemoService2.java
@@ -1,8 +1,0 @@
-package com.example.demo.service;
-
-import lombok.RequiredArgsConstructor;
-
-@RequiredArgsConstructor
-public class DemoService2 {
-
-}

--- a/src/main/java/com/example/demo/service/FeatureToggleRedisService.java
+++ b/src/main/java/com/example/demo/service/FeatureToggleRedisService.java
@@ -58,6 +58,19 @@ public class FeatureToggleRedisService implements FeatureToggleService {
         return featureToggleProvider.getAllFeature();
     }
 
+
+    @Override
+    public boolean updateToggleFeature(String featureId, boolean enabled) {
+        String rawRequest = writetoString(new FeatureMessageDto(String.valueOf(enabled), featureId));
+        try {
+            redisPublisher.publish(rawRequest);
+        } catch (Exception e){
+            log.error("FeatureToggleRedisService updateToggleFeature error", e);
+            throw new RuntimeException("FeatureToggleRedisService updateToggleFeature error");
+        }
+        return true;
+    }
+
     protected <T> T convert(String raw, Class<T> clazz) {
         try {
             return objectMapper.readValue(raw, clazz);

--- a/src/main/java/com/example/demo/service/FeatureToggleService.java
+++ b/src/main/java/com/example/demo/service/FeatureToggleService.java
@@ -23,4 +23,6 @@ public interface FeatureToggleService {
     FeatureMessageDto subscribeChangedToggleStatus(String message, String channel);
 
     List<Feature.Toggle> getAllFeature();
+
+    boolean updateToggleFeature(String featureId, boolean enabled);
 }

--- a/src/main/java/com/example/demo/service/RedisPublisher.java
+++ b/src/main/java/com/example/demo/service/RedisPublisher.java
@@ -1,5 +1,6 @@
 package com.example.demo.service;
 
+import com.example.demo.toggle.Toggle;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;

--- a/src/main/java/com/example/demo/toggle/FeatureToggleRedisProvider.java
+++ b/src/main/java/com/example/demo/toggle/FeatureToggleRedisProvider.java
@@ -4,14 +4,12 @@ import com.example.demo.model.Feature;
 import com.example.demo.repository.ToggleRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
 
 @Slf4j
 @Component
-@Repository
 public class FeatureToggleRedisProvider implements FeatureToggleProvider{
 
     private Map<String, Boolean> featureTogglesMap;

--- a/src/main/java/com/example/demo/toggle/Toggle.java
+++ b/src/main/java/com/example/demo/toggle/Toggle.java
@@ -9,6 +9,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME) // 런타임에도 어노테이션을 참조 가능하도록 설정
 @Target(ElementType.METHOD) //
 public @interface Toggle {
-    String value();
+    String featureId();
+    boolean enabled() default true;
     String fallbackMethod() default "default";
 }

--- a/src/main/java/com/example/demo/toggle/ToggleAspect.java
+++ b/src/main/java/com/example/demo/toggle/ToggleAspect.java
@@ -30,8 +30,8 @@ public class ToggleAspect {
 
     @Around(value = "matchAnnotation(toggle)", argNames = "joinPoint, toggle")
     public Object controlMethodByToggle(ProceedingJoinPoint joinPoint, Toggle toggle) throws Throwable {
-        if (featureToggleProvider.isFeatureEnabled(toggle.value())) {
-            log.info("toggle enabled : {}", toggle.value());
+        if (featureToggleProvider.isFeatureEnabled(toggle.featureId())) {
+            log.info("toggle enabled : {}", toggle.featureId());
             return joinPoint.proceed();
         }
         Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
@@ -40,7 +40,7 @@ public class ToggleAspect {
 
         String fallbackMethodName = toggle.fallbackMethod();
         CheckedSupplier<Object> checkedSupplier = () -> proceed(joinPoint, fallbackMethodName, returnType);
-        return fallbackExecutor.execute(joinPoint, toggle.value(), checkedSupplier);
+        return fallbackExecutor.execute(joinPoint, toggle.featureId(), checkedSupplier);
     }
 
     protected Object proceed(ProceedingJoinPoint joinPoint, String methodName, Class<?> returnType) throws Throwable {

--- a/src/main/java/com/example/demo/toggle/ToggleInitializer.java
+++ b/src/main/java/com/example/demo/toggle/ToggleInitializer.java
@@ -1,0 +1,60 @@
+package com.example.demo.toggle;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.framework.AopProxyUtils;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ClassUtils;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.springframework.aop.support.AopUtils.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ToggleInitializer implements ApplicationRunner {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ApplicationContext applicationContext;
+
+
+    public void init() {
+        for (String beanName : applicationContext.getBeanDefinitionNames()) {
+            Object obj = applicationContext.getBean(beanName);
+            Class<?> objClz = obj.getClass();
+            if (org.springframework.aop.support.AopUtils.isAopProxy(obj)) {
+                objClz = org.springframework.aop.support.AopUtils.getTargetClass(obj);
+            }
+            if (objClz.isAnnotationPresent(Service.class)) {
+                updateNewToggle(objClz);
+            }
+        }
+    }
+
+    void updateNewToggle(Class<?> clazz) {
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (method.isAnnotationPresent(Toggle.class)) {
+                Toggle toggle = method.getAnnotation(Toggle.class);
+                String featureId = toggle.featureId();
+                if (redisTemplate.opsForValue().get(featureId) == null) {
+                    redisTemplate.opsForValue().set(featureId, String.valueOf(toggle.enabled()));
+                }
+            }
+        }
+    }
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        init();
+    }
+}


### PR DESCRIPTION
# Describe
toggle 실시간 연동을 위한 api를 추가.

# Changes

`toggleId=${toggleId}&enabled=${enabled} ` 로 toggle 조작 가능하게 변경. 
pub: redis 값 및 channel에 pub
sub: sub 하여 application cache 수정


# Relate Issue
#1 